### PR TITLE
Add logical minimum and maximum to HID descriptor for analog axes.

### DIFF
--- a/USB_config/descriptors.c
+++ b/USB_config/descriptors.c
@@ -44,7 +44,7 @@
 
 uint16_t const report_desc_size[HID_NUM_INTERFACES] =
 {
-80
+85
 };
 uint8_t const report_len_input[HID_NUM_INTERFACES] =
 {
@@ -191,7 +191,7 @@ Collection(USB_HID_APPLICATION),
     Collection (USB_HID_PHYSICAL),
 
         //
-        // The X, Y and Z values which are specified as 8-bit absolute
+        // The X, Y and Z values which are specified as 12-bit absolute
         // position values.
         //
         Usage (USB_HID_X),
@@ -203,8 +203,11 @@ Collection(USB_HID_APPLICATION),
         Usage (USB_HID_SLIDER),
         Usage (USB_HID_DIAL),
         //
-        // 8 16-bit absolute values.
+        // 8 16-bit absolute values (but only 12 bit range due to 12-bit
+        // ADCs).
         //
+        LogicalMinimum(0),
+        LogicalMaximum16b(4095),
         ReportSize(16),
         ReportCount(8),
         Input(USB_HID_INPUT_DATA | USB_HID_INPUT_VARIABLE |

--- a/USB_config/descriptors.h
+++ b/USB_config/descriptors.h
@@ -136,7 +136,7 @@ extern "C"
 //***********************************************************************************************
 #define SIZEOF_DEVICE_DESCRIPTOR  0x12
 #define MAX_STRING_DESCRIPTOR_INDEX 5
-#define report_desc_size_HID0 80
+#define report_desc_size_HID0 85
 //#define SIZEOF_REPORT_DESCRIPTOR  36
 //#define USBHID_REPORT_LENGTH      64  // length of whole HID report (including Report ID)
 #define CONFIG_STRING_INDEX       4

--- a/USB_config/hidUsage.h
+++ b/USB_config/hidUsage.h
@@ -285,6 +285,25 @@ extern "C"
 
 //*****************************************************************************
 //
+//! This is a macro to assist adding Logical Maximum entries in HID report
+//! descriptors, when the representation of the logical maximum value requires
+//! 16 bits to represent.
+//!
+//! \param i16Value is the Logical Maximum value.
+//!
+//! This macro takes a value and prepares it to be placed as a Logical Maximum
+//! entry into a HID report structure.  This is the actual maximum value for
+//! the range of values associated with a field.
+//!
+//! \return Not a function.
+//
+//*****************************************************************************
+#define LogicalMaximum16b(i16Value)                                           \
+                                  0x26, ((i16Value) & 0xFF),                  \
+                                  (((i16Value) >> 8) & 0xFF)
+
+//*****************************************************************************
+//
 //! This is a macro to assist adding Physical Minimum entries in HID report
 //! descriptors.
 //!


### PR DESCRIPTION
Reporting a logical minimum (0) and maximum (2**12 - 1 = 4095)
that matches the range of the 12-bit A2D allows the host to scale
the analog inputs automatically, allowing use of the analog axes
without calibration.

This change required adding the LogicalMaximum16b macro, which
encodes a 2-byte logical maximum for use in the descriptor. (The
existing LogicalMaximum macro encodes a 1-byte value.)